### PR TITLE
Improvements to Gather/Push in Growth options

### DIFF
--- a/_docs/board_front.md
+++ b/_docs/board_front.md
@@ -52,7 +52,10 @@ General Images: Every image in a board can be called by simply using its name en
           - presence-no-range: Add a presence anywhere (as seen on Finder)
           - ignore-range: Ignore Range this turn (as seen on Finder)
           - gain-element(X): Gain X Element (currently limited to only one)
-          - push(x): Push x from land (as seen on Trickster with Dahan)
+          - push(x): Push x from your land (as seen on Trickster with Dahan)
+		  - push(x,y): Push x into a land at y range (as seen on Many Minds)
+		  - gather(x): Gather x into your land
+		  - gather(x,y): Gather x into a land at y range (as seen on Many Minds)
   - **presence-tracks**: The container for the Presence Tracks.
 
     There are two mechanisms to populate this. The simple approach is to use the specific energy and card tracks as demonstrated by the 'board_front' example.

--- a/_global/css/board_front/growth-options.css
+++ b/_global/css/board_front/growth-options.css
@@ -274,11 +274,14 @@ growth-cell icon.gain-card-play {
 }
 
 growth-cell icon.push>icon {
-  left: 0px;
-  top: 35px;
+  left: -15px;
+  top: 17px;
 }
 
-
+growth-cell icon.gather>icon {
+  left: 65px;
+  top: 17px;
+}
 
 growth-cell icon.reclaim-one {
   margin-bottom: 7px;
@@ -445,6 +448,26 @@ gather {
   height: 17px;
   margin-left: 45px;
   margin-top: -34px;
+}
+
+push-gather {
+  font-size: 20pt;
+  font-weight: bold;
+  display: block;
+  margin-top: 4px;
+  width: auto;
+  height: 110px;
+  margin-bottom: -22px;
+}
+
+push-gather-range-req {
+    font-size: 20pt;
+    font-weight: bold;
+    margin-top: -27px;
+    margin-bottom: 8px;
+    width: auto;
+    height: 110px;
+    display: block;
 }
 
 growth-cell gain icon.fire,

--- a/_global/css/board_front/icon.css
+++ b/_global/css/board_front/icon.css
@@ -360,22 +360,41 @@ icon.forget-power-card {
   width:90px;
 }
 
+icon.gather {
+  background-image: url('../../images/board/NewIcons/Land Gather.png');
+  display: inline-block;
+  height: 62px;
+  width:100px;
+  margin-right: 20px;
+}
+
+icon.gather > icon {
+    position: relative;
+    text-align: unset;
+    top: 17px;
+    left: 24px;
+    width: 30px;
+    height: 25px;
+    margin: 0px;
+    padding: 0px;
+}
+
 icon.push {
   background-image: url('../../images/board/NewIcons/Land Push.png');
-  display: block;
-  height: 100px;
+  display: inline-block;
+  height: 62px;
   width:100px;
 }
 
 icon.push > icon {
-  position: relative;
-  text-align: unset;
-  top: 32px;
-  left:26px;
-  width: 25px;
-  height: 25px;
-  margin: 0px;
-  padding: 0px;
+    position: relative;
+    text-align: unset;
+    top: 17px;
+    left: 24px;
+    width: 25px;
+    height: 25px;
+    margin: 0px;
+    padding: 0px;
 }
 
 icon.reclaim-all {

--- a/_global/js/board_front.js
+++ b/_global/js/board_front.js
@@ -341,13 +341,25 @@ function parseGrowthTags(){
                     break;
                 }
                 case 'push':
+				case 'gather':
                     {
                         const matches = regExp.exec(classPieces[j]);
-                        const pushTarget = matches[1];
-                        newGrowthCellHTML += `${openTag}<icon class='` + growthItem + "'><icon class='" + pushTarget + "'></icon></icon><growth-text>Push " + pushTarget + "</growth-text></growth-cell>"
-                        break;
-                    }
+						
+						let preposition = growthItem=='push'
+							? ' from'
+							: ' into'
 
+                        let pushTarget = matches[1];
+						const pushOptions = matches[1].split(",");
+						const pushRange = pushOptions[1];
+						if(pushRange){
+							pushTarget = pushOptions[0];
+							newGrowthCellHTML += `${openTag}<push-gather-range-req><icon class='` + growthItem + "'><icon class='" + pushTarget + "'></icon></icon>"+"{range-" + pushRange + "}</push-gather-range-req><growth-text>"+Capitalise(growthItem)+" up to 1 " + Capitalise(pushTarget) + preposition + " a Land</growth-text></growth-cell>"
+						}else{
+							newGrowthCellHTML += `${openTag}<push-gather><icon class='` + growthItem + "'><icon class='" + pushTarget + "'></icon></icon></push-gather><growth-text>"+Capitalise(growthItem)+" 1 " + Capitalise(pushTarget) + preposition + " 1 of your Lands</growth-text></growth-cell>"
+                        }
+						break;
+                    }
                 case 'presence-no-range':
                     {
                         newGrowthCellHTML += `${openTag}<custom-presence-no-range>+{presence}</custom-presence-no-range><growth-text>Add a Presence to any Land</growth-text></growth-cell>`


### PR DESCRIPTION
General improvements to pushing and gathering as growth options. Allows use at range. With no range specified, assumes 1 of your lands is target.